### PR TITLE
Cambio en printeo de posicion del camello

### DIFF
--- a/05-Camellos/src/main/java/es/joseluisgs/dam/HiloExt.java
+++ b/05-Camellos/src/main/java/es/joseluisgs/dam/HiloExt.java
@@ -18,8 +18,8 @@ public class HiloExt extends Thread{
         this.setName(name);
         while(ca.getPosicion()<100){
             avance=ca.avanzar();
-            System.out.println("El "+name+" ha avanzado "+avance+" posiciones y esta en la posición "+ca.getPosicion());
             ca.setPosicion(ca.getPosicion()+avance);
+            System.out.println("El "+name+" ha avanzado "+avance+" posiciones y esta en la posición "+ca.getPosicion());
             try {
                 Thread.sleep((long) (Math.random()*100));
             } catch (InterruptedException e) {


### PR DESCRIPTION
De esta forma, el camello actualiza su posición ANTES de printear, estando siempre el print un avance por detrás del valor real del campo.